### PR TITLE
fix: make plugin thread-safe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,20 +10,20 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.7.1'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.20'
+	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
-group = 'com.example'
+group = 'com.pinggraph'
 version = '1.4.1'
 sourceCompatibility = '1.8'
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Ping Graph
 author=yuh25
-support=
+support=https://github.com/yuh25/Ping-Grapher
 description=Graphs the ping to the current world
-tags=tool, ping, latency, graph, lag, connection, server
+tags=tool,ping,latency,graph,lag,connection,server
 plugins=com.pinggraph.PingGraphPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'ping-grapher'

--- a/src/test/java/com/pinggraph/PingGraphPluginTest.java
+++ b/src/test/java/com/pinggraph/PingGraphPluginTest.java
@@ -3,7 +3,6 @@ package com.pinggraph;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
-
 public class PingGraphPluginTest
 {
 	public static void main(String[] args) throws Exception


### PR DESCRIPTION
Avoids the following exception
```
2023-03-22 18:17:39 [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
        at java.base/java.util.LinkedList.node(LinkedList.java:576)
        at java.base/java.util.LinkedList.get(LinkedList.java:481)
        at com.pinggraph.PingGraphPlugin.getMaxMinFromList(PingGraphPlugin.java:159)
        at com.pinggraph.PingGraphPlugin.onClientTick(PingGraphPlugin.java:131)
        at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
        at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
        at net.runelite.client.callback.Hooks.post(Hooks.java:189)
        at client.vm(client.java:12204)
        at client.gt(client.java:3311)
        at client.bp(client.java:1110)
        at br.aa(br.java:367)
        at br.run(br.java:346)
        at java.base/java.lang.Thread.run(Thread.java:832)
```