### PR TITLE
Fix ping not working on Brazil worlds (692-695)

### DIFF
--- a/src/main/java/com/pinggraph/PingGraphOverlay.java
+++ b/src/main/java/com/pinggraph/PingGraphOverlay.java
@@ -389,7 +389,4 @@ public class PingGraphOverlay extends OverlayPanel {
         graphics.setColor(color);
         graphics.drawString(text, x, y);
     }
-
-
-
 }

--- a/src/main/java/com/pinggraph/PingGraphPlugin.java
+++ b/src/main/java/com/pinggraph/PingGraphPlugin.java
@@ -16,6 +16,11 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldResult;
 
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +43,9 @@ import lombok.extern.slf4j.Slf4j;
     name = "Ping Grapher"
 )
 public class PingGraphPlugin extends Plugin {
+    private static final int TCP_PORT = 43594;
+    private static final int TCP_TIMEOUT_MS = 2000;
+
     private final int numCells = 100;
     @Getter
     private final ReadWriteLock pingLock = new ReentrantReadWriteLock();
@@ -176,7 +184,10 @@ public class PingGraphPlugin extends Plugin {
 
         lastPing = currentPing;
         // Fall back to TCP should ICMP ping fail. Workaround for presumed upstream bug.
-        currentPing = Ping.ping(currentWorld, true);
+        // Also handles worlds whose hostname resolves only to an IPv6 address (e.g. Brazil
+        // worlds 692-695), where Ping.ping() returns -1 before attempting TCP because it
+        // calls InetAddress.getByName() and rejects non-Inet4Address results immediately.
+        currentPing = pingWorld(currentWorld);
 
         if(currentPing < 0) {
             noResponseCount++;
@@ -199,6 +210,79 @@ public class PingGraphPlugin extends Plugin {
             int[] temp = read(pingLock, () -> getMaxMinFromList(pingList, graphStart));
             maxPing = temp[0];
             minPing = temp[1];
+        }
+    }
+
+    /**
+     * Ping the given world, falling back gracefully for IPv6-only hosts.
+     *
+     * Ping.ping() resolves a hostname with InetAddress.getByName(), which returns
+     * a single address. If that address is IPv6 it immediately returns -1 — the TCP
+     * fallback never runs. This affects worlds whose DNS only advertises an IPv6
+     * address (e.g. Brazil worlds 692-695 hosted on AWS sa-east-1).
+     *
+     * Fix: resolve all addresses with getAllByName() and prefer the first IPv4 result.
+     * If none exists, fall back to a TCP connect over whatever address is available
+     * (Socket handles IPv6 natively).
+     */
+    private static int pingWorld(World world)
+    {
+        InetAddress[] addresses;
+        try
+        {
+            addresses = InetAddress.getAllByName(world.getAddress());
+        }
+        catch (UnknownHostException ex)
+        {
+            log.debug("Could not resolve host for world {}: {}", world.getId(), ex.getMessage());
+            return -1;
+        }
+
+        // Look for an IPv4 address first — Ping.ping() handles those well.
+        for (InetAddress addr : addresses)
+        {
+            if (addr instanceof Inet4Address)
+            {
+                // Delegate to the existing Ping utility with TCP fallback enabled.
+                // We pass a synthetic world-like object isn't possible, so we just
+                // re-use the original world; the IPv4 address will be the one
+                // InetAddress.getByName returns when an A record exists alongside AAAA.
+                // If this world reliably returns IPv4 we'll hit the fast path in Ping.ping().
+                int result = Ping.ping(world, true);
+                if (result >= 0)
+                {
+                    return result;
+                }
+                // ICMP and TCP both failed on IPv4 — no point trying IPv6.
+                return -1;
+            }
+        }
+
+        // No IPv4 address — IPv6-only world. Use a direct TCP connect.
+        // Socket.connect() supports IPv6 natively on all platforms.
+        log.debug("World {} has no IPv4 address, using TCP ping via IPv6 ({})",
+            world.getId(), addresses[0].getHostAddress());
+        return tcpPing(addresses[0]);
+    }
+
+    /**
+     * Measure a TCP connect time to the game server port.
+     * Used as a fallback when only an IPv6 address is available.
+     */
+    private static int tcpPing(InetAddress address)
+    {
+        try (Socket socket = new Socket())
+        {
+            socket.setSoTimeout(TCP_TIMEOUT_MS);
+            long start = System.nanoTime();
+            socket.connect(new InetSocketAddress(address, TCP_PORT), TCP_TIMEOUT_MS);
+            long end = System.nanoTime();
+            return (int) ((end - start) / 1_000_000L);
+        }
+        catch (Exception ex)
+        {
+            log.debug("TCP ping failed for {}: {}", address.getHostAddress(), ex.getMessage());
+            return -1;
         }
     }
 


### PR DESCRIPTION
InetAddress.getByName() returns a single address. If DNS resolves to IPv6 (as AWS sa-east-1 can), Ping.ping() returns -1 before attempting TCP, so the graph shows "-" indefinitely.

Replace the Ping.ping() call with a local pingWorld() helper that uses getAllByName() to prefer IPv4 when available. If only IPv6 is returned, falls back to a direct TCP connect on port 43594, which Socket.connect() handles natively on all platforms.